### PR TITLE
feat(crypto, vc): rlp encode function

### DIFF
--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -9,6 +9,7 @@ export * from './nacl';
 export * from './secp256k1';
 export * from './x25519';
 export * from './rescue';
+export * from './rlp';
 export * from './initCrypto';
 export * from './json';
 

--- a/packages/crypto/src/rlp/encode.spec.ts
+++ b/packages/crypto/src/rlp/encode.spec.ts
@@ -1,0 +1,31 @@
+// Copyright 2021-2022 zcloak authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { hexToU8a } from '@polkadot/util';
+
+import { initCrypto } from '../initCrypto';
+import { rlpEncode } from './encode';
+import * as official from './rlptest.json';
+
+describe('encode rlp', (): void => {
+  beforeEach(async (): Promise<void> => {
+    await initCrypto();
+  });
+
+  it('encode a string', (): void => {
+    for (const [testName, test] of Object.entries(official.tests) as [any, any]) {
+      let incoming: any = test.in;
+
+      // if we are testing a big number
+      if (incoming[0] === '#') {
+          incoming = BigInt(incoming.slice(1)) // eslint-disable-line
+      }
+
+      const encoded = rlpEncode(incoming);
+      const out = test.out;
+
+      expect(encoded).toEqual(hexToU8a(out));
+      console.log(`RLP ${testName} --- PASS`);
+    }
+  });
+});

--- a/packages/crypto/src/rlp/encode.ts
+++ b/packages/crypto/src/rlp/encode.ts
@@ -1,0 +1,104 @@
+// Copyright 2021-2022 zcloak authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '../types';
+import type { RlpInput } from './types';
+
+import {
+  hexStripPrefix,
+  hexToU8a,
+  isBigInt,
+  isBoolean,
+  isHex,
+  isNumber,
+  isString,
+  stringToU8a,
+  u8aConcat
+} from '@polkadot/util';
+
+/** Transform an integer into its hexadecimal value */
+function numberToHex(integer: number | bigint): HexString {
+  if (integer < 0) {
+    throw new Error('Invalid integer as argument, must be unsigned!');
+  }
+
+  const hex = integer.toString(16);
+
+  return hex.length % 2 ? `0x0${hex}` : `0x${hex}`;
+}
+
+export function rlpEncode(input: RlpInput | Array<RlpInput>): Uint8Array {
+  if (Array.isArray(input)) {
+    const output: Uint8Array[] = [];
+
+    for (let i = 0; i < input.length; i++) {
+      output.push(rlpEncode(input[i]));
+    }
+
+    const buf = u8aConcat(...output);
+
+    return u8aConcat(encodeLength(buf.length, 192), buf);
+  }
+
+  const inputBuf = toBytes(input);
+
+  if (inputBuf.length === 1 && inputBuf[0] < 128) {
+    return inputBuf;
+  }
+
+  return u8aConcat(encodeLength(inputBuf.length, 128), inputBuf);
+}
+
+function encodeLength(len: number, offset: number): Uint8Array {
+  if (len < 56) {
+    return Uint8Array.from([len + offset]);
+  }
+
+  const hexLength = hexStripPrefix(numberToHex(len));
+  const lLength = hexLength.length / 2;
+
+  const firstByte = numberToHex(offset + 55 + lLength);
+
+  return hexToU8a(firstByte + hexLength);
+}
+
+/** Transform anything into a Uint8Array */
+function toBytes(v: RlpInput): Uint8Array {
+  if (v instanceof Uint8Array) {
+    return v;
+  }
+
+  if (isBoolean(v)) {
+    v = Number(v);
+  }
+
+  if (isNumber(v)) {
+    if (!v) {
+      return Uint8Array.from([]);
+    }
+
+    return hexToU8a(numberToHex(Number(v)));
+  }
+
+  if (isBigInt(v)) {
+    if (!v) {
+      return Uint8Array.from([]);
+    }
+
+    return hexToU8a(numberToHex(v));
+  }
+
+  if (isHex(v)) {
+    return hexToU8a(v);
+  }
+
+  if (isString(v)) {
+    return stringToU8a(v);
+  }
+
+  if (v === null || v === undefined) {
+    return Uint8Array.from([]);
+  }
+
+  throw new Error('toBytes: received unsupported type ' + typeof v);
+}

--- a/packages/crypto/src/rlp/index.ts
+++ b/packages/crypto/src/rlp/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2021-2022 zcloak authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './encode';

--- a/packages/crypto/src/rlp/rlptest.json
+++ b/packages/crypto/src/rlp/rlptest.json
@@ -1,0 +1,175 @@
+{
+  "source": "https://github.com/ethereum/tests/blob/develop/RLPTests/rlptest.json",
+  "version": "ethereum/tests v6.0.0-beta.3",
+  "commit": "b2dcd19973637ac05e17646378dac9cbb2927075",
+  "date": "2019-01-14",
+  "tests": {
+    "emptystring": {
+      "in": "",
+      "out": "0x80"
+    },
+    "bytestring00": {
+      "in": "\u0000",
+      "out": "0x00"
+    },
+    "bytestring01": {
+      "in": "\u0001",
+      "out": "0x01"
+    },
+    "bytestring7F": {
+      "in": "\u007F",
+      "out": "0x7f"
+    },
+    "shortstring": {
+      "in": "dog",
+      "out": "0x83646f67"
+    },
+    "shortstring2": {
+      "in": "Lorem ipsum dolor sit amet, consectetur adipisicing eli",
+      "out": "0xb74c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c69"
+    },
+    "longstring": {
+      "in": "Lorem ipsum dolor sit amet, consectetur adipisicing elit",
+      "out": "0xb8384c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c6974"
+    },
+    "longstring2": {
+      "in": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur mauris magna, suscipit sed vehicula non, iaculis faucibus tortor. Proin suscipit ultricies malesuada. Duis tortor elit, dictum quis tristique eu, ultrices at risus. Morbi a est imperdiet mi ullamcorper aliquet suscipit nec lorem. Aenean quis leo mollis, vulputate elit varius, consequat enim. Nulla ultrices turpis justo, et posuere urna consectetur nec. Proin non convallis metus. Donec tempor ipsum in mauris congue sollicitudin. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Suspendisse convallis sem vel massa faucibus, eget lacinia lacus tempor. Nulla quis ultricies purus. Proin auctor rhoncus nibh condimentum mollis. Aliquam consequat enim at metus luctus, a eleifend purus egestas. Curabitur at nibh metus. Nam bibendum, neque at auctor tristique, lorem libero aliquet arcu, non interdum tellus lectus sit amet eros. Cras rhoncus, metus ac ornare cursus, dolor justo ultrices metus, at ullamcorper volutpat",
+      "out": "0xb904004c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061646970697363696e6720656c69742e20437572616269747572206d6175726973206d61676e612c20737573636970697420736564207665686963756c61206e6f6e2c20696163756c697320666175636962757320746f72746f722e2050726f696e20737573636970697420756c74726963696573206d616c6573756164612e204475697320746f72746f7220656c69742c2064696374756d2071756973207472697374697175652065752c20756c7472696365732061742072697375732e204d6f72626920612065737420696d70657264696574206d6920756c6c616d636f7270657220616c6971756574207375736369706974206e6563206c6f72656d2e2041656e65616e2071756973206c656f206d6f6c6c69732c2076756c70757461746520656c6974207661726975732c20636f6e73657175617420656e696d2e204e756c6c6120756c74726963657320747572706973206a7573746f2c20657420706f73756572652075726e6120636f6e7365637465747572206e65632e2050726f696e206e6f6e20636f6e76616c6c6973206d657475732e20446f6e65632074656d706f7220697073756d20696e206d617572697320636f6e67756520736f6c6c696369747564696e2e20566573746962756c756d20616e746520697073756d207072696d697320696e206661756369627573206f726369206c756374757320657420756c74726963657320706f737565726520637562696c69612043757261653b2053757370656e646973736520636f6e76616c6c69732073656d2076656c206d617373612066617563696275732c2065676574206c6163696e6961206c616375732074656d706f722e204e756c6c61207175697320756c747269636965732070757275732e2050726f696e20617563746f722072686f6e637573206e69626820636f6e64696d656e74756d206d6f6c6c69732e20416c697175616d20636f6e73657175617420656e696d206174206d65747573206c75637475732c206120656c656966656e6420707572757320656765737461732e20437572616269747572206174206e696268206d657475732e204e616d20626962656e64756d2c206e6571756520617420617563746f72207472697374697175652c206c6f72656d206c696265726f20616c697175657420617263752c206e6f6e20696e74657264756d2074656c6c7573206c65637475732073697420616d65742065726f732e20437261732072686f6e6375732c206d65747573206163206f726e617265206375727375732c20646f6c6f72206a7573746f20756c747269636573206d657475732c20617420756c6c616d636f7270657220766f6c7574706174"
+    },
+    "zero": {
+      "in": 0,
+      "out": "0x80"
+    },
+    "smallint": {
+      "in": 1,
+      "out": "0x01"
+    },
+    "smallint2": {
+      "in": 16,
+      "out": "0x10"
+    },
+    "smallint3": {
+      "in": 79,
+      "out": "0x4f"
+    },
+    "smallint4": {
+      "in": 127,
+      "out": "0x7f"
+    },
+    "mediumint1": {
+      "in": 128,
+      "out": "0x8180"
+    },
+    "mediumint2": {
+      "in": 1000,
+      "out": "0x8203e8"
+    },
+    "mediumint3": {
+      "in": 100000,
+      "out": "0x830186a0"
+    },
+    "mediumint4": {
+      "in": "#83729609699884896815286331701780722",
+      "out": "0x8f102030405060708090a0b0c0d0e0f2"
+    },
+    "mediumint5": {
+      "in": "#105315505618206987246253880190783558935785933862974822347068935681",
+      "out": "0x9c0100020003000400050006000700080009000a000b000c000d000e01"
+    },
+    "emptylist": {
+      "in": [],
+      "out": "0xc0"
+    },
+    "stringlist": {
+      "in": ["dog", "god", "cat"],
+      "out": "0xcc83646f6783676f6483636174"
+    },
+    "multilist": {
+      "in": ["zw", [4], 1],
+      "out": "0xc6827a77c10401"
+    },
+    "shortListMax1": {
+      "in": [
+        "asdf",
+        "qwer",
+        "zxcv",
+        "asdf",
+        "qwer",
+        "zxcv",
+        "asdf",
+        "qwer",
+        "zxcv",
+        "asdf",
+        "qwer"
+      ],
+      "out": "0xf784617364668471776572847a78637684617364668471776572847a78637684617364668471776572847a78637684617364668471776572"
+    },
+    "longList1": {
+      "in": [
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"]
+      ],
+      "out": "0xf840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
+    },
+    "longList2": {
+      "in": [
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"],
+        ["asdf", "qwer", "zxcv"]
+      ],
+      "out": "0xf90200cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
+    },
+    "listsoflists": {
+      "in": [[[], []], []],
+      "out": "0xc4c2c0c0c0"
+    },
+    "listsoflists2": {
+      "in": [[], [[]], [[], [[]]]],
+      "out": "0xc7c0c1c0c3c0c1c0"
+    },
+    "dictTest1": {
+      "in": [
+        ["key1", "val1"],
+        ["key2", "val2"],
+        ["key3", "val3"],
+        ["key4", "val4"]
+      ],
+      "out": "0xecca846b6579318476616c31ca846b6579328476616c32ca846b6579338476616c33ca846b6579348476616c34"
+    },
+    "bigint": {
+      "in": "#115792089237316195423570985008687907853269984665640564039457584007913129639936",
+      "out": "0xa1010000000000000000000000000000000000000000000000000000000000000000"
+    }
+  }
+}

--- a/packages/crypto/src/rlp/types.ts
+++ b/packages/crypto/src/rlp/types.ts
@@ -1,0 +1,14 @@
+// Copyright 2021-2022 zcloak authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '../types';
+
+export type RlpInput =
+  | string
+  | number
+  | boolean
+  | bigint
+  | HexString
+  | Uint8Array
+  | null
+  | undefined;

--- a/packages/vc/package.json
+++ b/packages/vc/package.json
@@ -17,7 +17,6 @@
   "version": "0.2.2",
   "main": "index.js",
   "dependencies": {
-    "@ethereumjs/rlp": "^4.0.0",
     "@polkadot/util": "^10.1.12",
     "@zcloak/crypto": "0.2.2",
     "@zcloak/ctype": "0.2.2",

--- a/packages/vc/src/utils.ts
+++ b/packages/vc/src/utils.ts
@@ -14,7 +14,6 @@ import type {
   VerifiablePresentationType
 } from './types';
 
-import { encode, Input } from '@ethereumjs/rlp';
 import {
   isArray,
   isHex,
@@ -25,7 +24,7 @@ import {
   isUndefined
 } from '@polkadot/util';
 
-import { isBase32, isBase58, isBase64 } from '@zcloak/crypto';
+import { isBase32, isBase58, isBase64, rlpEncode as rlpEncodeFn } from '@zcloak/crypto';
 import { isDidUrl } from '@zcloak/did/utils';
 
 import { ALL_HASH_TYPES, ALL_SIG_TYPES, ALL_VP_TYPES } from './defaults';
@@ -47,14 +46,7 @@ export function rlpEncode(
   input: NativeType | NativeTypeWithOutNull[],
   hashType: HashType
 ): Uint8Array {
-  const param: Input =
-    typeof input === 'boolean'
-      ? Number(input)
-      : Array.isArray(input)
-      ? input.map((inp) => (typeof inp === 'boolean' ? Number(inp) : inp))
-      : input;
-
-  const result = encode(param);
+  const result = rlpEncodeFn(input);
 
   if (hashType === 'RescuePrime') {
     return HASHER.RescuePrime(result, true);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,7 @@
       "@zcloak/wasm": ["wasm/src"],
       "@zcloak/wasm/*": ["wasm/src/*"],
     },
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,15 +1485,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/rlp@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@ethereumjs/rlp@npm:4.0.0"
-  bin:
-    rlp: bin/rlp
-  checksum: 407dfb8b1e09b4282e6be561e8d74f8939da78f460c08456c7ba2fb273fc42ee16027955a07085abfd7600ffb466c4c4add159885e67abb91bc85db9dd81ffb5
-  languageName: node
-  linkType: hard
-
 "@ethersproject/abi@npm:5.7.0, @ethersproject/abi@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/abi@npm:5.7.0"
@@ -3724,7 +3715,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zcloak/vc@workspace:packages/vc"
   dependencies:
-    "@ethereumjs/rlp": ^4.0.0
     "@polkadot/util": ^10.1.12
     "@zcloak/crypto": 0.2.2
     "@zcloak/ctype": 0.2.2


### PR DESCRIPTION
The @ethereum/rlp is incorrect for handling hex strings, we fix it and support `rlpEncode` function in @zcloak/crypto