### PR TITLE
feat: blake3_2to1AsU8a, add 2-to-1 blake3 Hash Function

### DIFF
--- a/packages/crypto/src/blake3-2to1/asU8a.spec.ts
+++ b/packages/crypto/src/blake3-2to1/asU8a.spec.ts
@@ -1,0 +1,145 @@
+// Copyright 2021-2022 zcloak authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { blake3 } from '@noble/hashes/blake3';
+
+import { initCrypto } from '../initCrypto';
+import { blake32to1AsU8a } from './asU8a';
+
+describe('blake32to1AsU8a', (): void => {
+  beforeEach(async (): Promise<void> => {
+    await initCrypto();
+  });
+
+  it('returns a 64-bit value by default', (): void => {
+    expect(blake32to1AsU8a('abc', 64, undefined)).toEqual(
+      new Uint8Array([100, 55, 179, 172, 56, 70, 81, 51])
+    );
+  });
+
+  it('returns a 128-bit value (as specified,)', (): void => {
+    expect(blake32to1AsU8a('abc', 128, undefined)).toEqual(
+      new Uint8Array([100, 55, 179, 172, 56, 70, 81, 51, 255, 182, 59, 117, 39, 58, 141, 181])
+    );
+  });
+
+  it('returns a 256-bit value (as specified, u8a.length is less than 32 bytes)', (): void => {
+    expect(blake32to1AsU8a(new Uint8Array([97, 98, 99]), 256, undefined)).toEqual(
+      new Uint8Array([
+        97, 98, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0
+      ])
+    );
+  });
+
+  it('returns a 256-bit value (as specified， u8a.length is 32bytes )', (): void => {
+    expect(
+      blake32to1AsU8a(
+        new Uint8Array([
+          54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0
+        ]),
+        256,
+        undefined
+      )
+    ).toEqual(
+      new Uint8Array([
+        54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0
+      ])
+    );
+  });
+
+  it('returns a 256-bit value (as specified， u8a.length between 33-64bytes )', (): void => {
+    // first 32 bytes: [54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    // second 32 bytes : [100];
+    const blake3Result = blake3(
+      new Uint8Array([
+        54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0
+      ])
+    );
+
+    expect(
+      blake32to1AsU8a(
+        new Uint8Array([
+          54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 100
+        ]),
+        256,
+        undefined
+      )
+    ).toEqual(blake3Result);
+  });
+
+  it('returns a 256-bit value (as specified， u8a.length is 64 bytes )', (): void => {
+    const firstlice = new Uint8Array([
+      54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0
+    ]);
+    const secSlice = new Uint8Array([
+      87, 155, 56, 57, 0, 48, 0, 148, 0, 133, 99, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 8, 0, 0, 0, 0, 0, 0,
+      10, 0, 0, 0
+    ]);
+    const paddingResult = new Uint8Array(64);
+
+    paddingResult.set(firstlice);
+    paddingResult.set(secSlice, 32);
+    const blake3Result = blake3(paddingResult);
+
+    expect(
+      blake32to1AsU8a(
+        new Uint8Array([
+          54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 87, 155, 56, 57, 0, 48, 0, 148, 0, 133, 99, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 8, 0,
+          0, 0, 0, 0, 0, 10, 0, 0, 0
+        ]),
+        256,
+        undefined
+      )
+    ).toEqual(blake3Result);
+  });
+
+  it('returns a 256-bit value (as specified， u8a.length is 64-96 bytes )', (): void => {
+    // first 32 bytes:[54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    // second 32 bytes: [87, 155, 56, 57, 0, 48, 0, 148, 0, 133, 99, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 8, 0, 0, 0, 0, 0, 0,10, 0, 0, 0]
+    const thirdSlice = new Uint8Array([107, 106]);
+    let blake3Result = blake3(
+      new Uint8Array([
+        54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 87, 155, 56, 57, 0, 48, 0, 148, 0, 133, 99, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 8, 0, 0,
+        0, 0, 0, 0, 10, 0, 0, 0
+      ])
+    );
+
+    const secondConcat = new Uint8Array(64);
+
+    secondConcat.set(blake3Result);
+    secondConcat.set(thirdSlice, 32);
+    blake3Result = blake3(secondConcat);
+
+    expect(
+      blake32to1AsU8a(
+        new Uint8Array([
+          54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 87, 155, 56, 57, 0, 48, 0, 148, 0, 133, 99, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 8, 0,
+          0, 0, 0, 0, 0, 10, 0, 0, 0, 107, 106
+        ]),
+        256,
+        undefined
+      )
+    ).toEqual(blake3Result);
+  });
+
+  it('returns a 512-bit value (as specified)', (): void => {
+    expect(blake32to1AsU8a('abc', 512, undefined)).toEqual(
+      new Uint8Array([
+        100, 55, 179, 172, 56, 70, 81, 51, 255, 182, 59, 117, 39, 58, 141, 181, 72, 197, 88, 70, 93,
+        121, 219, 3, 253, 53, 156, 108, 213, 189, 157, 133, 31, 178, 80, 174, 115, 147, 245, 208,
+        40, 19, 182, 93, 82, 26, 13, 73, 45, 155, 160, 156, 247, 206, 127, 76, 255, 217, 0, 242, 51,
+        116, 191, 11
+      ])
+    );
+  });
+});

--- a/packages/crypto/src/blake3-2to1/asU8a.ts
+++ b/packages/crypto/src/blake3-2to1/asU8a.ts
@@ -1,0 +1,72 @@
+// Copyright 2021-2022 zcloak authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { HexString } from '../types';
+
+import { blake3 } from '@noble/hashes/blake3';
+import { u8aToHex, u8aToU8a } from '@polkadot/util';
+
+/**
+ * @name blake32to1AsU8a
+ * @summary Creates a blake3 u8a from the input.
+ * @description
+ * From a `Uint8Array` input, create the blake3 using padding and iterative rules, and return the result as a u8a.
+ *
+ * If `bitLength` is not 256 by default, this function will get the same result as `blake3AsU8a` from `@zcloak/crypto`.
+ *
+ * If `bitLength` is 256, then this function will do the following things:
+ *   - If the `Uint8Array` input's length is less than 32, we will padding it to 32 bytes, and will not perform blake3.
+ *   - If the `Uint8Array` input's length is 33-64 bytes, we will padding it to 64 bytes, and do one-time blake3.
+ *   - If the `Uint8Array` input's length is 64-96 bytes, we will padding it to 96 bytes, and do blake3 for the first 64 bytes, and generate a 32-byte result; Then, concat the '32-bytes hash result' with the remain 32 bytes, do another blake3;
+ *
+ *    So, this function will automatically do padding and iterative blake3 hash for the `Uint8Array` input.
+ * @example
+ * <BR>
+ *
+ * ```javascript
+ * import { blake32to1AsU8a } from '@zcloak/crypto';
+ *
+ * blake32to1AsU8a(new Uint8Array([97, 98, 99])); // => [97, 98, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+ * blake32to1AsU8a(new Uint8Array([54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100])); // => [232, 47,  46, 107,  55, 116,  93, 176, 134, 64,  55, 208, 111, 192, 208, 198, 153, 56, 115, 176, 118, 175,  22,  23, 115, 46, 199, 235, 163, 203, 250,  51]
+ * ```
+ */
+export function blake32to1AsU8a(
+  data: HexString | Uint8Array | string,
+  bitLength: 64 | 128 | 256 | 384 | 512 = 256,
+  key?: Uint8Array | null
+): Uint8Array {
+  const byteLength = Math.ceil(bitLength / 8);
+  const u8a = u8aToU8a(data);
+  const sliceCount =
+    u8a.length % 32 === 0 ? Math.floor(u8a.length / 32) : Math.floor(u8a.length / 32) + 1;
+
+  const dataPadding = new Uint8Array(32 * sliceCount);
+
+  dataPadding.set(u8a);
+
+  let blake3Result = dataPadding.slice(0, 32);
+
+  // if the data is lte 32, we do not need to hash it.
+  if (sliceCount === 1) {
+    blake3Result = dataPadding;
+  } else {
+    for (let i = 1; i < sliceCount; i++) {
+      const interHash = new Uint8Array(64);
+
+      interHash.set(blake3Result);
+      interHash.set(dataPadding.slice(32 * i, 32 * (i + 1)), 32);
+      blake3Result = blake3(interHash, { dkLen: byteLength, key: key || undefined });
+    }
+  }
+
+  return byteLength === 32
+    ? blake3Result
+    : blake3(u8a, { dkLen: byteLength, key: key || undefined });
+}
+
+/**
+ * @description Creates a blake3 hex from the input.
+ */
+export function blake32to1AsHex(data: HexString | Uint8Array | string): HexString {
+  return u8aToHex(blake32to1AsU8a(data));
+}

--- a/packages/crypto/src/blake3-2to1/index.ts
+++ b/packages/crypto/src/blake3-2to1/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2021-2022 zcloak authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export { blake32to1AsHex, blake32to1AsU8a } from './asU8a';

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from './blake2';
 export * from './blake3';
+export * from './blake3-2to1';
 export * from './ed25519';
 export * from './ethereum';
 export * from './hmac';


### PR DESCRIPTION
feat(blake32to1AsU8a): add 2-to-1 blake3 Hash Function

This function offers a new 2-to-1 blake3 function, which do padding and iterative blake3 hash as described below:

- If bitLength is not 256 by default, this function will get the same result as blake3AsU8a from @zcloak/crypto.
- If bitLength is 256, then this function will do the following things:
  - If the Uint8Array input's length is less than 32, we will padding it to 32 bytes, and will not perform blake3.
  - If the Uint8Array input's length is 33-64 bytes, we will padding it to 64 bytes, and do one-time blake3.
  - If the Uint8Array input's length is 64-96 bytes, we will padding it to 96 bytes, and do blake3 for the first 64 bytes, and generate a 32-byte result; Then, concat the '32-bytes hash result' with the remain 32 bytes, do another blake3;

So, this function will automatically do padding and iterative blake3 hash for the Uint8Array input.